### PR TITLE
질문(관리자 포함), 알림 API 작업

### DIFF
--- a/Sources/QappleRepository/API/QappleAPI.swift
+++ b/Sources/QappleRepository/API/QappleAPI.swift
@@ -185,7 +185,7 @@ enum QappleAPI {
         static let basePath = "questions"
         
         case listOfMain
-        case list(threshold: String?, pageSize: Int32 = 25)
+        case list(threshold: Int?, pageSize: Int32 = 25)
         
         var rawValue: RawValue {
             switch self {
@@ -197,6 +197,27 @@ enum QappleAPI {
                     .init(key: "threshold", value: threshold),
                     .init(key: "pageSize", value: pageSize),
                 ])
+            }
+        }
+    }
+    
+    // MARK: - Admin Question
+    
+    enum AdminQuestion: RawRepresentable, API {
+        static let basePath = "admin/questions"
+        
+        case createQuestion
+        case deleteQuestion(questionId: Int64)
+        case uploadCSV
+        
+        var rawValue: RawValue {
+            switch self {
+            case .createQuestion:
+                appending()
+            case .deleteQuestion(let questionId):
+                appending(baseString: "\(questionId)")
+            case .uploadCSV:
+                appending(baseString: "upload/csv")
             }
         }
     }

--- a/Sources/QappleRepository/DTO/AdminQuestion/CreateQuestion.swift
+++ b/Sources/QappleRepository/DTO/AdminQuestion/CreateQuestion.swift
@@ -1,0 +1,26 @@
+//
+//  CreateQuestion.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+
+public struct CreateQuestion: Decodable, Sendable {
+    public let questionId: Int
+}
+
+
+public struct CreateQuestionRequest: Encodable, Sendable {
+    public let questionStatus: String
+    public let content: String
+    
+    public enum QuestionStatus: String {
+        case live = "LIVE"
+        case old = "OLD"
+        case hold = "HOLD"
+        case pending = "PENDING"
+    }
+}

--- a/Sources/QappleRepository/DTO/AdminQuestion/DeleteQuestion.swift
+++ b/Sources/QappleRepository/DTO/AdminQuestion/DeleteQuestion.swift
@@ -1,0 +1,13 @@
+//
+//  DeleteQuestion.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+
+public struct DeleteQuestion: Decodable, Sendable {
+    public let questionId: Int
+}

--- a/Sources/QappleRepository/DTO/AdminQuestion/UploadCSV.swift
+++ b/Sources/QappleRepository/DTO/AdminQuestion/UploadCSV.swift
@@ -1,0 +1,8 @@
+//
+//  UploadCSV.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+// MARK: 어떻게 구현 해?

--- a/Sources/QappleRepository/DTO/Notification/NotificationList.swift
+++ b/Sources/QappleRepository/DTO/Notification/NotificationList.swift
@@ -1,0 +1,28 @@
+//
+//  Notification.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+
+public struct NotificationList: Decodable, Sendable {
+    public let total: Int?
+    public let size: Int
+    public let content: [Content]
+    public let numberOfElements: Int
+    public let threshold: String
+    public let hasNext: Bool
+    
+    public struct Content: Decodable, Sendable {
+        public let title: String
+        public let subtitle: String?
+        public let content: String?
+        public let boardId: String?
+        public let questionId: String?
+        public let boardCommentId: String?
+        public let createdAt: String
+    }
+}

--- a/Sources/QappleRepository/DTO/Question/MainQuestion.swift
+++ b/Sources/QappleRepository/DTO/Question/MainQuestion.swift
@@ -1,0 +1,16 @@
+//
+//  MainQuestion.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+
+public struct MainQuestion: Decodable, Sendable {
+    public let questionId: Int
+    public let questionStatus: String
+    public let content: String
+    public let isAnswered: Bool
+}

--- a/Sources/QappleRepository/DTO/Question/Question.swift
+++ b/Sources/QappleRepository/DTO/Question/Question.swift
@@ -1,0 +1,26 @@
+//
+//  Question.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+
+public struct Question: Decodable, Sendable {
+    public let total: Int
+    public let size: Int
+    public let content: [Content]
+    public let numberOfElements: Int
+    public let threshold: String
+    public let hasNext: Bool
+    
+    public struct Content: Decodable, Sendable {
+        public let questionId: Int
+        public let questionStatus: String
+        public let livedAt: String?
+        public let content: String
+        public let isAnswered: Bool
+    }
+}

--- a/Sources/QappleRepository/NetworkService/NetworkService.swift
+++ b/Sources/QappleRepository/NetworkService/NetworkService.swift
@@ -47,6 +47,11 @@ enum NetworkService {
         let (data, response) = try await request(url: url, method: .DELETE, accessToken: accessToken)
         return try decodeResponse(data: data, response: response)
     }
+    
+//    static func postCSV(url: URL, csvData: Data, accessToken: String = "") async throws -> Int {
+//        let (data, response) = try await requestFormData(url: url, data: csvData, method: .POST, accessToken: accessToken)
+//        return try decodeResponse(data: data, response: response)
+//    }
 }
 
 // MARK: - URLSession
@@ -73,6 +78,30 @@ extension NetworkService {
             throw NetworkError.urlRequestFailure(urlString: url.absoluteString)
         }
     }
+    
+//    static func requestFormData(url: URL, data: Data, method: HTTPMethod, accessToken: String) async throws -> (Data, URLResponse) {
+//        do {
+//            let accessToken = "Bearer \(accessToken)"
+//            let boundary = "Boundary-\(UUID().uuidString)"
+//            
+//            var request = URLRequest(url: url)
+//            request.httpMethod = method.rawValue
+//            request.setValue(accessToken, forHTTPHeaderField: "Authorization")
+//            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+//            
+//            var body = Data()
+//            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+//            body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\("file.csv")\"\r\n".data(using: .utf8)!)
+//            body.append("Content-Type: text/csv\r\n\r\n".data(using: .utf8)!)
+//            body.append(data)
+//            body.append("\r\n".data(using: .utf8)!)
+//            body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+//            
+//            return try await URLSession.shared.upload(for: request, from: body)
+//        } catch {
+//            throw NetworkError.urlRequestFailure(urlString: url.absoluteString)
+//        }
+//    }
 }
 
 // MARK: - Status Code

--- a/Sources/QappleRepository/UseCase/AdminQuestionAPI.swift
+++ b/Sources/QappleRepository/UseCase/AdminQuestionAPI.swift
@@ -1,0 +1,42 @@
+//
+//  AdminQuestionAPI.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+/**
+ Admin 계정으로 질문을 관리하는 API
+ */
+public enum AdminQuestionAPI: Sendable {
+    /// 질문을 생성하는 API 입니다.
+    public static func createQuestion(
+        questionStatus: CreateQuestionRequest.QuestionStatus,
+        content: String,
+        server: Server,
+        accessToken: String
+    ) async throws -> CreateQuestion {
+        let url = try QappleAPI.AdminQuestion.createQuestion
+            .url(from: server)
+        let request = CreateQuestionRequest(
+            questionStatus: questionStatus.rawValue,
+            content: content
+        )
+        
+        return try await NetworkService.post(url: url, body: request)
+    }
+    
+    /// 질문을 삭제하는 API 입니다.
+    public static func deleteQuestion(
+        questionId: Int,
+        server: Server,
+        accessToken: String
+    ) async throws -> DeleteQuestion {
+        let url = try QappleAPI.AdminQuestion.deleteQuestion(questionId: Int64(questionId))
+            .url(from: server)
+        
+        return try await NetworkService.delete(url: url, accessToken: accessToken)
+    }
+}

--- a/Sources/QappleRepository/UseCase/AdminQuestionAPI.swift
+++ b/Sources/QappleRepository/UseCase/AdminQuestionAPI.swift
@@ -25,7 +25,7 @@ public enum AdminQuestionAPI: Sendable {
             content: content
         )
         
-        return try await NetworkService.post(url: url, body: request)
+        return try await NetworkService.post(url: url, body: request, accessToken: accessToken)
     }
     
     /// 질문을 삭제하는 API 입니다.
@@ -39,4 +39,15 @@ public enum AdminQuestionAPI: Sendable {
         
         return try await NetworkService.delete(url: url, accessToken: accessToken)
     }
+    
+//    public static func createQuestionWithCSV(
+//        file: Data,
+//        server: Server,
+//        accessToken: String
+//    ) async throws -> Int {
+//        let url = try QappleAPI.AdminQuestion.uploadCSV
+//            .url(from: server)
+//        
+//        return try await NetworkService.postCSV(url: url, csvData: file, accessToken: accessToken)
+//    }
 }

--- a/Sources/QappleRepository/UseCase/NotificationAPI.swift
+++ b/Sources/QappleRepository/UseCase/NotificationAPI.swift
@@ -1,0 +1,28 @@
+//
+//  NotificationAPI.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+/**
+ 알림 리스트 API
+ */
+public enum NotificationAPI: Sendable {
+    /// 알림 목록을 조회하는 API 입니다.
+    public static func fetchNotifications(
+        threshold: Int?,
+        pageSize: Int,
+        server: Server,
+        accessToken: String
+    ) async throws -> NotificationList {
+        let url = try QappleAPI.Notification.list(
+            threshold: threshold,
+            pageSize: Int32(pageSize)
+        ).url(from: server)
+        
+        return try await NetworkService.get(url: url, accessToken: accessToken)
+    }
+}

--- a/Sources/QappleRepository/UseCase/QuestionAPI.swift
+++ b/Sources/QappleRepository/UseCase/QuestionAPI.swift
@@ -1,0 +1,39 @@
+//
+//  QuestionAPI.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+
+/**
+ 질문 관련 API
+ */
+public enum QuestionAPI: Sendable {
+    /// 질문 목록을 불러오는 API 입니다.
+    public static func fetchQuestionList(
+        threshold: Int?,
+        pageSize: Int,
+        server: Server,
+        accessToken: String
+    ) async throws -> Question {
+        let url = try QappleAPI.Question.list(
+            threshold: threshold,
+            pageSize: Int32(pageSize)
+        ).url(from: server)
+        
+        return try await NetworkService.get(url: url, accessToken: accessToken)
+    }
+    
+    /// 현재 LIVE인 질문을 불러오는 API 입니다.
+    public static func fetchMainQuestion(
+        server: Server,
+        accessToken: String
+    ) async throws -> MainQuestion {
+        let url = try QappleAPI.Question.listOfMain
+            .url(from: server)
+        
+        return try await NetworkService.get(url: url, accessToken: accessToken)
+    }
+}

--- a/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
+++ b/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
@@ -1,0 +1,45 @@
+//
+//  AdminQuestionAPITests.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+import Testing
+@testable import QappleRepository
+
+
+struct AdminQuestionAPITests {
+    
+    @Test("Admin 질문 생성 테스트")
+    func createQuestion() async throws {
+        let response = try await AdminQuestionAPI.createQuestion(
+            questionStatus: .pending,
+            content: "테스트 질문입니다!",
+            server: .test,
+            accessToken: TestHelper.shared.testToken()
+        )
+        
+        dump(response)
+    }
+    
+    @Test("Admin 질문 삭제 테스트")
+    func deleteQuestion() async throws {
+        let token = try await TestHelper.shared.testToken()
+        let createResponse = try await AdminQuestionAPI.createQuestion(
+            questionStatus: .pending,
+            content: "테스트 질문입니다!",
+            server: .test,
+            accessToken: token
+        )
+        
+        let deleteResponse = try await AdminQuestionAPI.deleteQuestion(
+            questionId: createResponse.questionId,
+            server: .test,
+            accessToken: token
+        )
+        
+        dump(deleteResponse)
+    }
+}

--- a/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
+++ b/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
@@ -42,4 +42,19 @@ struct AdminQuestionAPITests {
         
         dump(deleteResponse)
     }
+    
+//    @Test("Admin 질문 CSV 파일 업로드 테스트")
+//    func uploadQuestionsCSV() async throws {
+//        let token = try await TestHelper.shared.testToken()
+//        let file = Bundle.module.url(forResource: "test", withExtension: ".csv")!
+//        let data = try! Data(contentsOf: file)
+//        
+//        let response = try await AdminQuestionAPI.createQuestionWithCSV(
+//            file: data,
+//            server: .test,
+//            accessToken: TestHelper.shared.testToken()
+//        )
+//        
+//        dump(response)
+//    }
 }

--- a/Tests/QappleRepositoryTests/NotificationAPITests.swift
+++ b/Tests/QappleRepositoryTests/NotificationAPITests.swift
@@ -12,7 +12,7 @@ import Testing
 
 struct NotificationAPITests {
     
-    @Test("")
+    @Test("알림 리스트 조회 테스트")
     func fetchNotifications() async throws {
         let response = try await NotificationAPI.fetchNotifications(
             threshold: nil,

--- a/Tests/QappleRepositoryTests/NotificationAPITests.swift
+++ b/Tests/QappleRepositoryTests/NotificationAPITests.swift
@@ -1,0 +1,26 @@
+//
+//  NotificationAPITests.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Foundation
+import Testing
+@testable import QappleRepository
+
+
+struct NotificationAPITests {
+    
+    @Test("")
+    func fetchNotifications() async throws {
+        let response = try await NotificationAPI.fetchNotifications(
+            threshold: nil,
+            pageSize: 25,
+            server: .test,
+            accessToken: TestHelper.shared.testToken()
+        )
+        
+        dump(response)
+    }
+}

--- a/Tests/QappleRepositoryTests/QuestionAPITests.swift
+++ b/Tests/QappleRepositoryTests/QuestionAPITests.swift
@@ -1,0 +1,36 @@
+//
+//  QuestionAPITests.swift
+//  QappleRepository
+//
+//  Created by 문인범 on 2/14/25.
+//
+
+import Testing
+import Foundation
+@testable import QappleRepository
+
+
+struct QuestionAPITests {
+    
+    @Test("질문 리스트 조회 테스트")
+    func fetchQuestions() async throws {
+        let response = try await QuestionAPI.fetchQuestionList(
+            threshold: nil,
+            pageSize: 25,
+            server: .test,
+            accessToken: TestHelper.shared.testToken()
+        )
+        
+        dump(response)
+    }
+    
+    @Test("메인 질문 조회 테스트")
+    func fetchMainQuestion() async throws {
+        let response = try await QuestionAPI.fetchMainQuestion(
+            server: .test,
+            accessToken: TestHelper.shared.testToken()
+        )
+        
+        dump(response)
+    }
+}


### PR DESCRIPTION
close #7 

## 구현 내용
* 질문(관리자 포함), 알림 API 구현
* 관련 API 테스트 코드 작성


## 스크린 샷

* 질문 관련 API 테스트
<img width="562" alt="스크린샷 2025-02-15 오전 1 21 20" src="https://github.com/user-attachments/assets/8a56bbf7-9ed0-4deb-8bac-c39fc77530b4" />

* 알림 관련 API 테스트
<img width="603" alt="스크린샷 2025-02-15 오전 1 21 55" src="https://github.com/user-attachments/assets/4e1de37f-aa48-4409-a5a7-37a8f71248d6" />


* 관리자 질문 추가 및 삭제 API 테스트
<img width="633" alt="스크린샷 2025-02-15 오전 12 25 41" src="https://github.com/user-attachments/assets/f63d199b-6807-4191-b91d-651e55656176" />


## 추가 내용
* 관리자 API 중 csv파일 업로드가 있습니다. 매크로 프로젝트 할 때 http request로 pdf를 post 했어서 비슷하게 짜봤는데 잘 안되서 일단은 주석처리 해놓았습니다!! 여러분들의 열렬한 훈수 기다리고 있겠습니다 ㅎㅎ ㅜㅜ