### PR TITLE
Request 구조체 생성 방식 수정

### DIFF
--- a/Sources/QappleRepository/DTO/Member/SignUp.swift
+++ b/Sources/QappleRepository/DTO/Member/SignUp.swift
@@ -17,16 +17,4 @@ public struct SignUpRequest: Encodable, Sendable {
     public let email: String
     public let nickname: String
     public let deviceToken: String
-    
-    public init(
-        signUpToken: String,
-        email: String,
-        nickname: String,
-        deviceToken: String
-    ) {
-        self.signUpToken = signUpToken
-        self.email = email
-        self.nickname = nickname
-        self.deviceToken = deviceToken
-    }
 }

--- a/Sources/QappleRepository/UseCase/AnswerAPI.swift
+++ b/Sources/QappleRepository/UseCase/AnswerAPI.swift
@@ -52,13 +52,14 @@ public enum AnswerAPI: Sendable {
     
     /// 답변 생성 API 입니다.
     public static func create(
-        request: CreateAnswerRequest,
+        content: String,
         questionId: Int,
         server: Server,
         accessToken: String
     ) async throws -> CreateAnswer {
         let url = try QappleAPI.Answer.create(questionId: Int64(questionId))
             .url(from: server)
+        let request = CreateAnswerRequest(answer: content)
         return try await NetworkService.post(
             url: url,
             body: request,

--- a/Sources/QappleRepository/UseCase/BoardAPI.swift
+++ b/Sources/QappleRepository/UseCase/BoardAPI.swift
@@ -62,11 +62,12 @@ public enum BoardAPI {
     
     /// 게시글 좋아요 및 취소 API입니다.
     public static func like(
-        request: LikeBoardRequest,
+        boardId: Int,
         server: Server,
         accessToken: String
     ) async throws -> LikeBoard {
-        let url = try QappleAPI.Board.like(boardId: Int64(request.boardId)).url(from: server)
+        let url = try QappleAPI.Board.like(boardId: Int64(boardId)).url(from: server)
+        let request = LikeBoardRequest(boardId: boardId)
         return try await NetworkService.post(url: url, body: request, accessToken: accessToken)
     }
     

--- a/Sources/QappleRepository/UseCase/MemberAPI.swift
+++ b/Sources/QappleRepository/UseCase/MemberAPI.swift
@@ -44,11 +44,19 @@ public enum MemberAPI: Sendable {
     
     /// 회원가입 API 입니다.
     public static func signUp(
-        request: SignUpRequest,
+        signUpToken: String,
+        email: String,
+        nickname: String,
+        deviceToken: String,
         server: Server
     ) async throws -> SignUp {
         let url = try QappleAPI.Member.signUp.url(from: server)
-        
+        let request = SignUpRequest(
+            signUpToken: signUpToken,
+            email: email,
+            nickname: nickname,
+            deviceToken: deviceToken
+        )
         return try await NetworkService.post(
             url: url,
             body: request

--- a/Tests/QappleRepositoryTests/AnswerAPITests.swift
+++ b/Tests/QappleRepositoryTests/AnswerAPITests.swift
@@ -15,7 +15,7 @@ struct AnswerAPITests {
     func fetchListOfMine() async throws {
         let accessToken = try await TestHelper.shared.testToken()
         let _ = try await AnswerAPI.create(
-            request: .init(answer: "테스트 답변"),
+            content: "테스트 답변",
             questionId: 1,
             server: .test,
             accessToken: accessToken
@@ -33,7 +33,7 @@ struct AnswerAPITests {
     func delete() async throws {
         let accessToken = try await TestHelper.shared.testToken()
         let createAnswer = try await AnswerAPI.create(
-            request: .init(answer: "테스트 답변"),
+            content: "테스트 답변",
             questionId: 1,
             server: .test,
             accessToken: accessToken
@@ -61,7 +61,7 @@ struct AnswerAPITests {
     @Test("답변 생성 테스트")
     func create() async throws {
         let response = try await AnswerAPI.create(
-            request: .init(answer: "테스트 답변"),
+            content: "테스트 답변",
             questionId: 1,
             server: .test,
             accessToken: TestHelper.shared.testToken()

--- a/Tests/QappleRepositoryTests/BoardAPITests.swift
+++ b/Tests/QappleRepositoryTests/BoardAPITests.swift
@@ -67,7 +67,7 @@ struct BoardAPITests {
     func like() async throws {
         let accessToken = try await TestHelper.shared.testToken()
         let response = try await BoardAPI.like(
-            request: .init(boardId: 1),
+            boardId: 1,
             server: .test,
             accessToken: accessToken
         )

--- a/Tests/QappleRepositoryTests/MemberAPITests.swift
+++ b/Tests/QappleRepositoryTests/MemberAPITests.swift
@@ -29,12 +29,10 @@ struct MemberAPITests {
             server: .test
         ).refreshToken
         let response = try await MemberAPI.signUp(
-            request: .init(
-                signUpToken: refreshToken,
-                email: "email",
-                nickname: "nickname",
-                deviceToken: "deviceToken"
-            ),
+            signUpToken: refreshToken,
+            email: "email",
+            nickname: "nickname",
+            deviceToken: "deviceToken",
             server: .test
         )
         dump(response)

--- a/Tests/QappleRepositoryTests/ReportTests.swift
+++ b/Tests/QappleRepositoryTests/ReportTests.swift
@@ -15,7 +15,7 @@ struct ReportTests {
     func reportAnswer() async throws {
         let accessToken = try await TestHelper.shared.testToken()
         let createAnswer = try await AnswerAPI.create(
-            request: .init(answer: "테스트 답변"),
+            content: "테스트 답변",
             questionId: 1,
             server: .test,
             accessToken: accessToken

--- a/Tests/QappleRepositoryTests/TestHelper+.swift
+++ b/Tests/QappleRepositoryTests/TestHelper+.swift
@@ -26,12 +26,10 @@ final class TestHelper {
                 server: .test
             )
             let localSignUp = try await MemberAPI.signUp(
-                request: .init(
-                    signUpToken: localSignIn.refreshToken,
-                    email: "email",
-                    nickname: "nickname",
-                    deviceToken: "deviceToken"
-                ),
+                signUpToken: localSignIn.refreshToken,
+                email: "email",
+                nickname: "nickname",
+                deviceToken: "deviceToken",
                 server: .test
             )
             return localSignUp.accessToken ?? ""


### PR DESCRIPTION
기존 POST 혹은 PATH API를 호출하기 위해 Encodable 프로토콜을 준수한 Request 구조체를 사용처에서 직접 구현해 사용했어야 했습니다.
~~~swift
let request = CreateAnswerRequest(answer: "답변입니다.")
NetworkService.post(url: url, body: request, accessToken: accessToken)
~~~

하지만 기존 Request 구조체의 생성자에 public 접근 제어자가 누락되어 있었고, 이를 접근제어자를 붙여 해결하는 것보다 함수의 인자로 값을 모두 받아 모듈 내부에서 Request를 생성하는 식으로 업데이트했습니다.