### PR TITLE
CI를 위한 UnitTest 연결

### DIFF
--- a/Sources/QappleRepository/API/QappleAPI.swift
+++ b/Sources/QappleRepository/API/QappleAPI.swift
@@ -94,6 +94,9 @@ enum QappleAPI {
         /// 사용자 자격 변경
         case roleChange(role: String)
         
+        /// 메일 인증 화이트 리스트 등록
+        case emailWhitelist(mail: String, whitelistDurationMinutes: Int64)
+        
         var rawValue: RawValue {
             switch self {
             case let .certification(signUpToken, email):
@@ -146,6 +149,12 @@ enum QappleAPI {
             case let .roleChange(role):
                 appending(baseString: "role/change", urlQueryItems: [
                     .init(key: "role", value: role)
+                ])
+                
+            case let .emailWhitelist(mail, whitelistDurationMinutes):
+                appending(baseString: "email/whitelist/register", urlQueryItems: [
+                    .init(key: "mail", value: mail),
+                    .init(key: "whitelistDurationMinutes", value: whitelistDurationMinutes)
                 ])
             }
         }

--- a/Sources/QappleRepository/API/QappleAPI.swift
+++ b/Sources/QappleRepository/API/QappleAPI.swift
@@ -91,6 +91,9 @@ enum QappleAPI {
         /// 회원가입
         case signUp
         
+        /// 사용자 자격 변경
+        case roleChange(role: String)
+        
         var rawValue: RawValue {
             switch self {
             case let .certification(signUpToken, email):
@@ -139,9 +142,13 @@ enum QappleAPI {
                 
             case .signUp:
                 appending(baseString: "sign-up")
+                
+            case let .roleChange(role):
+                appending(baseString: "role/change", urlQueryItems: [
+                    .init(key: "role", value: role)
+                ])
             }
         }
-        
     }
     
     // MARK: - Board

--- a/Sources/QappleRepository/DTO/Member/RoleChange.swift
+++ b/Sources/QappleRepository/DTO/Member/RoleChange.swift
@@ -1,0 +1,13 @@
+//
+//  RoleChange.swift
+//  QappleRepository
+//
+//  Created by Simmons on 2/12/25.
+//
+
+import Foundation
+
+public struct RoleChange: Decodable, Sendable {
+    public let accessToken: String
+    public let refreshToken: String
+}

--- a/Sources/QappleRepository/Entity/MemberRole.swift
+++ b/Sources/QappleRepository/Entity/MemberRole.swift
@@ -1,0 +1,13 @@
+//
+//  MemberRole.swift
+//  QappleRepository
+//
+//  Created by 김민준 on 3/1/25.
+//
+
+import Foundation
+
+public enum MemberRole: String, Sendable {
+    case academier = "ROLE_ACADEMIER"
+    case admin = "ROLE_ADMIN"
+}

--- a/Sources/QappleRepository/UseCase/MemberAPI.swift
+++ b/Sources/QappleRepository/UseCase/MemberAPI.swift
@@ -168,4 +168,18 @@ public enum MemberAPI: Sendable {
         let url = try QappleAPI.Member.roleChange(role: role.rawValue).url(from: server)
         return try await NetworkService.get(url: url, accessToken: accessToken)
     }
+    
+    /// 메일 인증 화이트 리스트 등록 API 입니다.
+    public static func emailWhitelist(
+        email: String,
+        durationMinutes: Int,
+        server: Server,
+        accessToken: String
+    ) async throws -> Bool {
+        let url = try QappleAPI.Member.emailWhitelist(
+            mail: email,
+            whitelistDurationMinutes: Int64(durationMinutes)
+        ).url(from: server)
+        return try await NetworkService.get(url: url, accessToken: accessToken)
+    }
 }

--- a/Sources/QappleRepository/UseCase/MemberAPI.swift
+++ b/Sources/QappleRepository/UseCase/MemberAPI.swift
@@ -158,4 +158,14 @@ public enum MemberAPI: Sendable {
             accessToken: accessToken
         )
     }
+    
+    /// 사용자 자격 변경 API 입니다.
+    public static func roleChange(
+        role: MemberRole,
+        server: Server,
+        accessToken: String
+    ) async throws -> RoleChange {
+        let url = try QappleAPI.Member.roleChange(role: role.rawValue).url(from: server)
+        return try await NetworkService.get(url: url, accessToken: accessToken)
+    }
 }

--- a/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
+++ b/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
@@ -12,7 +12,7 @@ import Testing
 
 struct AdminQuestionAPITests {
     
-    @Test("Admin 질문 생성 테스트")
+    @Test("Admin 질문 생성 및 삭제 테스트")
     func createQuestion() async throws {
         let token = try await TestHelper.accessToken()
         let _ = try await MemberAPI.roleChange(
@@ -26,29 +26,11 @@ struct AdminQuestionAPITests {
             server: .test,
             accessToken: token
         )
-        dump(createQuestion)
-    }
-    
-    @Test("Admin 질문 삭제 테스트")
-    func deleteQuestion() async throws {
-        let token = try await TestHelper.accessToken()
-        let _ = try await MemberAPI.roleChange(
-            role: .admin,
+        let _ = try await AdminQuestionAPI.deleteQuestion(
+            questionId: createQuestion.questionId,
             server: .test,
             accessToken: token
         )
-        let createResponse = try await AdminQuestionAPI.createQuestion(
-            questionStatus: .pending,
-            content: "테스트 질문입니다!",
-            server: .test,
-            accessToken: token
-        )
-        let deleteResponse = try await AdminQuestionAPI.deleteQuestion(
-            questionId: createResponse.questionId,
-            server: .test,
-            accessToken: token
-        )
-        dump(deleteResponse)
     }
     
 //    @Test("Admin 질문 CSV 파일 업로드 테스트")

--- a/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
+++ b/Tests/QappleRepositoryTests/AdminQuestionAPITests.swift
@@ -14,32 +14,40 @@ struct AdminQuestionAPITests {
     
     @Test("Admin 질문 생성 테스트")
     func createQuestion() async throws {
-        let response = try await AdminQuestionAPI.createQuestion(
+        let token = try await TestHelper.accessToken()
+        let _ = try await MemberAPI.roleChange(
+            role: .admin,
+            server: .test,
+            accessToken: token
+        )
+        let createQuestion = try await AdminQuestionAPI.createQuestion(
             questionStatus: .pending,
             content: "테스트 질문입니다!",
             server: .test,
-            accessToken: TestHelper.accessToken()
+            accessToken: token
         )
-        
-        dump(response)
+        dump(createQuestion)
     }
     
     @Test("Admin 질문 삭제 테스트")
     func deleteQuestion() async throws {
         let token = try await TestHelper.accessToken()
+        let _ = try await MemberAPI.roleChange(
+            role: .admin,
+            server: .test,
+            accessToken: token
+        )
         let createResponse = try await AdminQuestionAPI.createQuestion(
             questionStatus: .pending,
             content: "테스트 질문입니다!",
             server: .test,
             accessToken: token
         )
-        
         let deleteResponse = try await AdminQuestionAPI.deleteQuestion(
             questionId: createResponse.questionId,
             server: .test,
             accessToken: token
         )
-        
         dump(deleteResponse)
     }
     

--- a/Tests/QappleRepositoryTests/AnswerAPITests.swift
+++ b/Tests/QappleRepositoryTests/AnswerAPITests.swift
@@ -11,61 +11,36 @@ import Foundation
 
 struct AnswerAPITests {
     
-    @Test("내가 작성한 답변 리스트 테스트")
+    @Test("답변 생성, 내 답변 확인, 답변 삭제 테스트")
     func fetchListOfMine() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let _ = try await AnswerAPI.create(
+        let create = try await AnswerAPI.create(
             content: "테스트 답변",
             questionId: 1,
             server: .test,
             accessToken: accessToken
         )
-        let response = try await AnswerAPI.fetchListOfMine(
+        let _ = try await AnswerAPI.fetchListOfMine(
             threshold: nil,
             pageSize: 30,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
-    }
-    
-    @Test("답변 삭제 테스트")
-    func delete() async throws {
-        let accessToken = try await TestHelper.accessToken()
-        let createAnswer = try await AnswerAPI.create(
-            content: "테스트 답변",
-            questionId: 1,
+        let _ = try await AnswerAPI.delete(
+            answerId: create.answerId,
             server: .test,
             accessToken: accessToken
         )
-        let deleteAnswer = try await AnswerAPI.delete(
-            answerId: createAnswer.answerId,
-            server: .test,
-            accessToken: accessToken
-        )
-        dump(deleteAnswer)
     }
     
     @Test("질문에 대한 답변 리스트 테스트")
     func fetchListOfQuestion() async throws {
-        let response = try await AnswerAPI.fetchListOfQuestion(
+        let _ = try await AnswerAPI.fetchListOfQuestion(
             questionId: 1,
             threshold: nil,
             pageSize: 30,
             server: .test,
             accessToken: TestHelper.accessToken()
         )
-        dump(response)
-    }
-    
-    @Test("답변 생성 테스트")
-    func create() async throws {
-        let response = try await AnswerAPI.create(
-            content: "테스트 답변",
-            questionId: 1,
-            server: .test,
-            accessToken: TestHelper.accessToken()
-        )
-        dump(response)
     }
 }

--- a/Tests/QappleRepositoryTests/BoardAPITests.swift
+++ b/Tests/QappleRepositoryTests/BoardAPITests.swift
@@ -14,76 +14,58 @@ struct BoardAPITests {
     @Test("게시글 리스트 조회 테스트")
     func fetchList() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await BoardAPI.fetchList(
+        let _ = try await BoardAPI.fetchList(
             threshold: nil,
             pageSize: 30,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
-    }
-    
-    @Test("게시글 생성 테스트")
-    func create() async throws {
-        let accessToken = try await TestHelper.accessToken()
-        let response = try await BoardAPI.create(
-            content: "테스트 게시글",
-            boardType: .freeBoard,
-            server: .test,
-            accessToken: accessToken
-        )
-        dump(response)
     }
     
     @Test("게시글 단건 조회 테스트")
     func fetchSingle() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await BoardAPI.fetchSingle(
+        let _ = try await BoardAPI.fetchSingle(
             boardId: 1,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
     
-    @Test("게시글 삭제 테스트")
-    func delete() async throws {
+    @Test("게시글 생성, 좋아요 및 취소, 검색, 삭제 테스트")
+    func create() async throws {
         let accessToken = try await TestHelper.accessToken()
+        let title = "테스트 게시글"
         let create = try await BoardAPI.create(
-            content: "테스트 게시글",
+            content: title,
             boardType: .freeBoard,
             server: .test,
             accessToken: accessToken
         )
-        let delete = try await BoardAPI.fetchSingle(
+        let like = try await BoardAPI.like(
             boardId: create.boardId,
             server: .test,
             accessToken: accessToken
         )
-        dump(delete)
-    }
-    
-    @Test("게시글 좋아요 및 취소 테스트")
-    func like() async throws {
-        let accessToken = try await TestHelper.accessToken()
-        let response = try await BoardAPI.like(
-            boardId: 1,
+        #expect(like.isLiked)
+        let disLike = try await BoardAPI.like(
+            boardId: create.boardId,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
-    }
-    
-    @Test("게시글 검색 테스트")
-    func search() async throws {
-        let accessToken = try await TestHelper.accessToken()
-        let response = try await BoardAPI.search(
-            keyword: "ㅇ",
+        #expect(!disLike.isLiked)
+        let search = try await BoardAPI.search(
+            keyword: title,
             threshold: nil,
             pageSize: 30,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
+        #expect(!search.content.isEmpty)
+        let _ = try await BoardAPI.fetchSingle(
+            boardId: create.boardId,
+            server: .test,
+            accessToken: accessToken
+        )
     }
 }

--- a/Tests/QappleRepositoryTests/BoardCommentAPITests.swift
+++ b/Tests/QappleRepositoryTests/BoardCommentAPITests.swift
@@ -14,63 +14,40 @@ struct BoardCommentAPITests {
     @Test("게시글 댓글 리스트 조회 테스트")
     func fetchList() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await BoardCommentAPI.fetchList(
+        let _ = try await BoardCommentAPI.fetchList(
             boardId: 1,
             threshold: nil,
             pageSize: 30,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
     
-    @Test("게시글 댓글 생성 테스트")
+    @Test("게시글 댓글 생성, 좋아요 및 취소, 삭제 테스트")
     func create() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await BoardCommentAPI.create(
+        let create = try await BoardCommentAPI.create(
             boardId: 1,
             content: "테스트 댓글",
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
-    }
-    
-    @Test("게시글 댓글 삭제 테스트")
-    func delete() async throws {
-        let accessToken = try await TestHelper.accessToken()
-        // 댓글 생성
-        let createComment = try await BoardCommentAPI.create(
-            boardId: 1,
-            content: "삭제할 댓글",
+        let like = try await BoardCommentAPI.like(
+            commentId: create.boardCommentId,
             server: .test,
             accessToken: accessToken
         )
-        // 생성한 댓글 삭제
-        let deleteComment = try await BoardCommentAPI.delete(
-            commentId: createComment.boardCommentId,
+        #expect(like.isLiked)
+        let disLike = try await BoardCommentAPI.like(
+            commentId: create.boardCommentId,
             server: .test,
             accessToken: accessToken
         )
-        dump(deleteComment)
-    }
-    
-    @Test("게시글 댓글 좋아요 및 취소 테스트")
-    func like() async throws {
-        let accessToken = try await TestHelper.accessToken()
-        // 댓글 생성
-        let createComment = try await BoardCommentAPI.create(
-            boardId: 1,
-            content: "좋아요 테스트 댓글",
+        #expect(!disLike.isLiked)
+        let _ = try await BoardCommentAPI.delete(
+            commentId: create.boardCommentId,
             server: .test,
             accessToken: accessToken
         )
-        // 생성한 댓글에 좋아요
-        let likeComment = try await BoardCommentAPI.like(
-            commentId: createComment.boardCommentId,
-            server: .test,
-            accessToken: accessToken
-        )
-        dump(likeComment)
     }
 }

--- a/Tests/QappleRepositoryTests/MemberAPITests.swift
+++ b/Tests/QappleRepositoryTests/MemberAPITests.swift
@@ -55,41 +55,41 @@ struct MemberAPITests {
     
     @Test("회원가입 인증코드 확인 테스트")
     func checkAuthCode() async throws {
-        // TODO: 메일 인증 화이트리스트 API 관련 이슈 해결 필요
-//        let testEmail = "test\(Date.now.timeIntervalSince1970)@pos.idserve.net"
-//        let testId = "TEST_ID_\(Date.now.description)"
-//        let testDeviceToken = "TEST_DEVICE_TOKEN"
-//        
-//        let localSignUp = try await MemberAPI.localSignIn(
-//            testId: testId,
-//            deviceToken: testDeviceToken,
-//            server: .test
-//        )
-//        let signUp = try await MemberAPI.signUp(
-//            signUpToken: localSignUp.refreshToken,
-//            email: testEmail,
-//            nickname: "nickname",
-//            deviceToken: testDeviceToken,
-//            server: .test
-//        )
-//        let _ = try await MemberAPI.roleChange(
-//            role: .admin,
-//            server: .test,
-//            accessToken: signUp.accessToken ?? ""
-//        )
-//        let _ = try await MemberAPI.emailWhitelist(
-//            email: testEmail,
-//            durationMinutes: 1,
-//            server: .test,
-//            accessToken: signUp.accessToken ?? ""
-//        )
-//        let response = try await MemberAPI.checkAuthCode(
-//            signUpToken: signUp.refreshToken ?? "",
-//            email: testEmail,
-//            certCode: "CERT7",
-//            server: .test
-//        )
-//        dump(response)
+        let now = Date.now
+        let testEmail = "test\(now.timeIntervalSince1970)date25@pos.idserve.net"
+        
+        let accessToken = try await TestHelper.accessToken()
+        let _ = try await MemberAPI.roleChange(
+            role: .admin,
+            server: .test,
+            accessToken: accessToken
+        )
+        let _ = try await MemberAPI.emailWhitelist(
+            email: testEmail,
+            durationMinutes: 10,
+            server: .test,
+            accessToken: accessToken
+        )
+        let localSignUp = try await MemberAPI.localSignIn(
+            testId: "TEST_ID_\(now.description)",
+            deviceToken: "TEST_DEVICE_TOKEN_\(now.description)",
+            server: .test
+        )
+        let _ = try await MemberAPI.sendCertificationEmail(
+            signUpToken: localSignUp.refreshToken,
+            email: testEmail,
+            server: .test
+        )
+        guard let certCode = ProcessInfo.processInfo.environment["CERT_CODE"] else {
+            throw RepositoryError.invalidSecretKey("CERT_CODE")
+        }
+        let response = try await MemberAPI.checkAuthCode(
+            signUpToken: localSignUp.refreshToken,
+            email: testEmail,
+            certCode: certCode,
+            server: .test
+        )
+        dump(response)
     }
     
     @Test("닉네임 중복 확인 테스트")

--- a/Tests/QappleRepositoryTests/MemberAPITests.swift
+++ b/Tests/QappleRepositoryTests/MemberAPITests.swift
@@ -11,52 +11,49 @@ import Foundation
 
 struct MemberAPITests {
     
-    @Test
+    @Test("테스트용 로컬 로그인")
     func localSignIn() async throws {
-        let response = try await MemberAPI.localSignIn(
-            testId: "TEST_ID_\(Date.now.description)",
+        let _ = try await MemberAPI.localSignIn(
+            testId: "TEST_ID_\(UUID())",
             deviceToken: "TEST_DEVICE_TOKEN",
             server: .test
         )
-        dump(response)
     }
     
-    @Test
+    @Test("테스트용 로컬 회원가입")
     func localSignUp() async throws {
         let refreshToken = try await MemberAPI.localSignIn(
-            testId: "TEST_ID_\(Date.now.description)",
+            testId: "TEST_ID_\(UUID())",
             deviceToken: "TEST_DEVICE_TOKEN",
             server: .test
         ).refreshToken
-        let response = try await MemberAPI.signUp(
+        let _ = try await MemberAPI.signUp(
             signUpToken: refreshToken,
             email: "email",
             nickname: "nickname",
             deviceToken: "deviceToken",
             server: .test
         )
-        dump(response)
     }
     
     @Test("회원가입 인증메일 발송 테스트")
     func sendCertificationEmail() async throws {
         let refreshToken = try await MemberAPI.localSignIn(
-            testId: "TEST_ID_\(Date.now.description)",
+            testId: "TEST_ID_\(UUID())",
             deviceToken: "TEST_DEVICE_TOKEN",
             server: .test
         ).refreshToken
-        let response = try await MemberAPI.sendCertificationEmail(
+        let _ = try await MemberAPI.sendCertificationEmail(
             signUpToken: refreshToken,
             email: "test@pos.idserve.net",
             server: .test
         )
-        dump(response)
     }
     
     @Test("회원가입 인증코드 확인 테스트")
     func checkAuthCode() async throws {
-        let now = Date.now
-        let testEmail = "test\(now.timeIntervalSince1970)date25@pos.idserve.net"
+        let uuid = UUID()
+        let testEmail = "test\(uuid)date25@pos.idserve.net"
         
         let accessToken = try await TestHelper.accessToken()
         let _ = try await MemberAPI.roleChange(
@@ -71,8 +68,8 @@ struct MemberAPITests {
             accessToken: accessToken
         )
         let localSignUp = try await MemberAPI.localSignIn(
-            testId: "TEST_ID_\(now.description)",
-            deviceToken: "TEST_DEVICE_TOKEN_\(now.description)",
+            testId: "TEST_ID_\(uuid)",
+            deviceToken: "TEST_DEVICE_TOKEN_\(uuid)",
             server: .test
         )
         let _ = try await MemberAPI.sendCertificationEmail(
@@ -83,55 +80,50 @@ struct MemberAPITests {
         guard let certCode = ProcessInfo.processInfo.environment["CERT_CODE"] else {
             throw RepositoryError.invalidSecretKey("CERT_CODE")
         }
-        let response = try await MemberAPI.checkAuthCode(
+        let _ = try await MemberAPI.checkAuthCode(
             signUpToken: localSignUp.refreshToken,
             email: testEmail,
             certCode: certCode,
             server: .test
         )
-        dump(response)
     }
     
     @Test("닉네임 중복 확인 테스트")
     func checkNicknameDuplicate() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await MemberAPI.checkNicknameDuplicate(
+        let _ = try await MemberAPI.checkNicknameDuplicate(
             nickname: "TestUser",
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
     
     @Test("프로필 조회 테스트")
     func fetchProfile() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await MemberAPI.fetchProfile(
+        let _ = try await MemberAPI.fetchProfile(
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
     
     @Test("프로필 수정 테스트")
     func updateProfile() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await MemberAPI.updateProfile(
-            nickname: "User\(Int.random(in: 1...100))",
+        let _ = try await MemberAPI.updateProfile(
+            nickname: "User\(Int.random(in: 0...99999))",
             profileImage: nil,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
     
     @Test("회원탈퇴 테스트")
     func resign() async throws {
         let accessToken = try await TestHelper.accessToken()
-        let response = try await MemberAPI.resign(
+        let _ = try await MemberAPI.resign(
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
 }

--- a/Tests/QappleRepositoryTests/MemberAPITests.swift
+++ b/Tests/QappleRepositoryTests/MemberAPITests.swift
@@ -55,18 +55,41 @@ struct MemberAPITests {
     
     @Test("회원가입 인증코드 확인 테스트")
     func checkAuthCode() async throws {
-        let refreshToken = try await MemberAPI.localSignIn(
-            testId: "TEST_ID_\(Date.now.description)",
-            deviceToken: "TEST_DEVICE_TOKEN",
-            server: .test
-        ).refreshToken
-        let response = try await MemberAPI.checkAuthCode(
-            signUpToken: refreshToken,
-            email: "test@pos.idserve.net",
-            certCode: "123456",
-            server: .test
-        )
-        dump(response)
+        // TODO: 메일 인증 화이트리스트 API 관련 이슈 해결 필요
+//        let testEmail = "test\(Date.now.timeIntervalSince1970)@pos.idserve.net"
+//        let testId = "TEST_ID_\(Date.now.description)"
+//        let testDeviceToken = "TEST_DEVICE_TOKEN"
+//        
+//        let localSignUp = try await MemberAPI.localSignIn(
+//            testId: testId,
+//            deviceToken: testDeviceToken,
+//            server: .test
+//        )
+//        let signUp = try await MemberAPI.signUp(
+//            signUpToken: localSignUp.refreshToken,
+//            email: testEmail,
+//            nickname: "nickname",
+//            deviceToken: testDeviceToken,
+//            server: .test
+//        )
+//        let _ = try await MemberAPI.roleChange(
+//            role: .admin,
+//            server: .test,
+//            accessToken: signUp.accessToken ?? ""
+//        )
+//        let _ = try await MemberAPI.emailWhitelist(
+//            email: testEmail,
+//            durationMinutes: 1,
+//            server: .test,
+//            accessToken: signUp.accessToken ?? ""
+//        )
+//        let response = try await MemberAPI.checkAuthCode(
+//            signUpToken: signUp.refreshToken ?? "",
+//            email: testEmail,
+//            certCode: "CERT7",
+//            server: .test
+//        )
+//        dump(response)
     }
     
     @Test("닉네임 중복 확인 테스트")

--- a/Tests/QappleRepositoryTests/NotificationAPITests.swift
+++ b/Tests/QappleRepositoryTests/NotificationAPITests.swift
@@ -14,13 +14,11 @@ struct NotificationAPITests {
     
     @Test("알림 리스트 조회 테스트")
     func fetchNotifications() async throws {
-        let response = try await NotificationAPI.fetchNotifications(
+        let _ = try await NotificationAPI.fetchNotifications(
             threshold: nil,
             pageSize: 25,
             server: .test,
             accessToken: TestHelper.accessToken()
         )
-        
-        dump(response)
     }
 }

--- a/Tests/QappleRepositoryTests/QuestionAPITests.swift
+++ b/Tests/QappleRepositoryTests/QuestionAPITests.swift
@@ -32,17 +32,13 @@ struct QuestionAPITests {
             
             #expect(response.content.first!.questionId != pagination.content.first!.questionId)
         }
-        
-        dump(response)
     }
     
     @Test("메인 질문 조회 테스트")
     func fetchMainQuestion() async throws {
-        let response = try await QuestionAPI.fetchMainQuestion(
+        let _ = try await QuestionAPI.fetchMainQuestion(
             server: .test,
             accessToken: TestHelper.accessToken()
         )
-        
-        dump(response)
     }
 }

--- a/Tests/QappleRepositoryTests/QuestionAPITests.swift
+++ b/Tests/QappleRepositoryTests/QuestionAPITests.swift
@@ -14,11 +14,12 @@ struct QuestionAPITests {
     
     @Test("질문 리스트 조회 테스트")
     func fetchQuestions() async throws {
+        let accessToken = try await TestHelper.accessToken()
         let response = try await QuestionAPI.fetchQuestionList(
             threshold: nil,
             pageSize: 25,
             server: .test,
-            accessToken: TestHelper.accessToken()
+            accessToken: accessToken
         )
         
         if response.hasNext {
@@ -26,7 +27,7 @@ struct QuestionAPITests {
                 threshold: response.threshold,
                 pageSize: 25,
                 server: .test,
-                accessToken: TestHelper.accessToken()
+                accessToken: accessToken
             )
             
             #expect(response.content.first!.questionId != pagination.content.first!.questionId)

--- a/Tests/QappleRepositoryTests/ReportTests.swift
+++ b/Tests/QappleRepositoryTests/ReportTests.swift
@@ -50,9 +50,14 @@ struct ReportTests {
     @Test("게시글 댓글 신고 테스트")
     func reportBoardComment() async throws {
         let accessToken = try await TestHelper.accessToken()
-        // TODO: 테스트 댓글 API 연결 필요
+        let _ = try await BoardCommentAPI.create(
+            boardId: 1,
+            content: "테스트 댓글",
+            server: .test,
+            accessToken: accessToken
+        )
         let response = try await ReportAPI.reportBoardComment(
-            boardCommentId: 0,
+            boardCommentId: 1,
             reportType: .DISTRIBUTION_OF_ILLEGAL_PHOTOGRAPHS,
             server: .test,
             accessToken: accessToken

--- a/Tests/QappleRepositoryTests/ReportTests.swift
+++ b/Tests/QappleRepositoryTests/ReportTests.swift
@@ -20,13 +20,12 @@ struct ReportTests {
             server: .test,
             accessToken: accessToken
         )
-        let response = try await ReportAPI.reportAnswer(
+        let _ = try await ReportAPI.reportAnswer(
             answerId: createAnswer.answerId,
             reportType: .ABUSIVE_LANGUAGE_AND_DISPARAGEMENT,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
     
     @Test("게시글 신고 테스트")
@@ -38,13 +37,12 @@ struct ReportTests {
             server: .test,
             accessToken: accessToken
         )
-        let response = try await ReportAPI.reportBoard(
+        let _ = try await ReportAPI.reportBoard(
             boardId: createBoard.boardId,
             reportType: .COMMERCIAL_ADVERTISING_AND_SALES,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
     
     @Test("게시글 댓글 신고 테스트")
@@ -56,12 +54,11 @@ struct ReportTests {
             server: .test,
             accessToken: accessToken
         )
-        let response = try await ReportAPI.reportBoardComment(
+        let _ = try await ReportAPI.reportBoardComment(
             boardCommentId: 1,
             reportType: .DISTRIBUTION_OF_ILLEGAL_PHOTOGRAPHS,
             server: .test,
             accessToken: accessToken
         )
-        dump(response)
     }
 }

--- a/Tests/QappleRepositoryTests/TestHelper+.swift
+++ b/Tests/QappleRepositoryTests/TestHelper+.swift
@@ -13,7 +13,7 @@ enum TestHelper {
     /// 테스트 토큰을 발급합니다.
     static func accessToken() async throws -> String {
         let localSignIn = try await MemberAPI.localSignIn(
-            testId: "TEST_ID_\(Date.now.description)",
+            testId: "TEST_ID_\(UUID())",
             deviceToken: "TEST_DEVICE_TOKEN",
             server: .test
         )


### PR DESCRIPTION
### TO-DO
- [x] 관리자 권한 변경 API 연결
- [x] 메일 인증 화이트리스트 API 연결
- [x] 전체 Unit Test 성공 확인

CI를 위한 전체 Unit Test가 통과할 수 있도록 구현해봤는데,, 어쩐 이유에서인지 유닛 테스트 결과가 항상 다르게 반환됩니다. 이것저것 삽질을 해본 결과 요청 시간이 초과되었을 때 테스트 실패를 보내는 것 같습니다!

그래서 CI에 유닛 테스트를 적용하는 것에 대해,, 조금은 더 논의가 필요해 보이긴 합니다!

![image](https://github.com/user-attachments/assets/375fe5ba-b869-465b-abe1-ae5bec0b8d0a)

++ 인증코드 환경변수를 추가했습니다. Scheme에 추가 부탁드립니다!
![image](https://github.com/user-attachments/assets/a655471f-e868-40e3-8b25-7ec912f6ce8c)